### PR TITLE
Add texture format 110

### DIFF
--- a/fmt_FGOA_bin.py
+++ b/fmt_FGOA_bin.py
@@ -445,6 +445,8 @@ def getTextureFormat(format):
         return noesis.FOURCC_DXT3
     elif format == 109:
         return noesis.FOURCC_DXT5
+    elif format == 110:
+        return noesis.FOURCC_DXT5
     elif format == 112:
         return noesis.FOURCC_ATI1
     elif format == 115:


### PR DESCRIPTION
Add missing texture format 110 used by the following:
```
svt_0028_s06_tex.bin
svt_0028_s04_tex.bin
```